### PR TITLE
Make a copy of markdown.css to this package instead of reading from the `markdown.HTML.stylesheet` option

### DIFF
--- a/R/html.R
+++ b/R/html.R
@@ -78,7 +78,7 @@ setMethod("html", "character", function(object, corpus, height = NULL){
 
   css <- paste(
     c(
-      readLines(getOption("markdown.HTML.stylesheet")),
+      readLines(system.file("resources", "markdown.css", package = "markdown")),
       readLines(system.file("css", "tooltips.css", package = "polmineR"))
     ),
     collapse = "\n", sep = "\n"

--- a/R/html.R
+++ b/R/html.R
@@ -78,7 +78,7 @@ setMethod("html", "character", function(object, corpus, height = NULL){
 
   css <- paste(
     c(
-      readLines(system.file("resources", "markdown.css", package = "markdown")),
+      readLines(system.file("css", "markdown.css", package = "polmineR")),
       readLines(system.file("css", "tooltips.css", package = "polmineR"))
     ),
     collapse = "\n", sep = "\n"

--- a/inst/css/markdown.css
+++ b/inst/css/markdown.css
@@ -1,0 +1,134 @@
+body, td {
+   font-family: sans-serif;
+   background-color: white;
+   font-size: 13px;
+}
+
+body {
+  max-width: 800px;
+  margin: auto;
+  padding: 1em;
+  line-height: 20px;
+}
+
+tt, code, pre {
+   font-family: 'DejaVu Sans Mono', 'Droid Sans Mono', 'Lucida Console', Consolas, Monaco, monospace;
+}
+
+h1 {
+   font-size:2.2em;
+}
+
+h2 {
+   font-size:1.8em;
+}
+
+h3 {
+   font-size:1.4em;
+}
+
+h4 {
+   font-size:1.0em;
+}
+
+h5 {
+   font-size:0.9em;
+}
+
+h6 {
+   font-size:0.8em;
+}
+
+a:visited {
+   color: rgb(50%, 0%, 50%);
+}
+
+pre, img {
+  max-width: 100%;
+}
+pre {
+  overflow-x: auto;
+}
+pre code {
+   display: block; padding: 0.5em;
+}
+
+code {
+  font-size: 92%;
+  border: 1px solid #ccc;
+}
+
+code[class] {
+  background-color: #F8F8F8;
+}
+
+table, td, th {
+  border: none;
+}
+
+blockquote {
+   color:#666666;
+   margin:0;
+   padding-left: 1em;
+   border-left: 0.5em #EEE solid;
+}
+
+hr {
+   height: 0px;
+   border-bottom: none;
+   border-top-width: thin;
+   border-top-style: dotted;
+   border-top-color: #999999;
+}
+
+@media print {
+   * {
+      background: transparent !important;
+      color: black !important;
+      filter:none !important;
+      -ms-filter: none !important;
+   }
+
+   body {
+      font-size:12pt;
+      max-width:100%;
+   }
+
+   a, a:visited {
+      text-decoration: underline;
+   }
+
+   hr {
+      visibility: hidden;
+      page-break-before: always;
+   }
+
+   pre, blockquote {
+      padding-right: 1em;
+      page-break-inside: avoid;
+   }
+
+   tr, img {
+      page-break-inside: avoid;
+   }
+
+   img {
+      max-width: 100% !important;
+   }
+
+   @page :left {
+      margin: 15mm 20mm 15mm 10mm;
+   }
+
+   @page :right {
+      margin: 15mm 10mm 15mm 20mm;
+   }
+
+   p, h2, h3 {
+      orphans: 3; widows: 3;
+   }
+
+   h2, h3 {
+      page-break-after: avoid;
+   }
+}


### PR DESCRIPTION
Because the option might be unset. It will be unset in a future version of the **markdown** package. On the other hand, the css in **markdown** can change (in fact it has changed in v1.4). To stabilize tests in **polmineR**, I suggest you make a copy of `markdown.css` (or change your tests so that they won't be affected by future changes in **markdown**'s css). Thanks!

Fixes #235.